### PR TITLE
Add OXXO retail analytics skeleton

### DIFF
--- a/oxxo-retail-predictive-analytics/README.md
+++ b/oxxo-retail-predictive-analytics/README.md
@@ -1,0 +1,68 @@
+# OXXO Retail Predictive Analytics
+
+Este proyecto simula un caso de ciencia de datos para el sector retail tomando como referencia los datos de Instacart. El objetivo principal es entender y predecir el comportamiento de compra de los clientes para proponer promociones personalizadas.
+
+## Estructura del proyecto
+
+```
+oxxo-retail-predictive-analytics/
+│
+├── data/                             # CSVs originales Instacart
+├── notebooks/
+│   ├── 01_ingesta_datos.ipynb
+│   ├── 02_exploracion_analitica.ipynb
+│   ├── 03_segmentacion_clientes.ipynb
+│   ├── 04_modelo_recompra_clientes.ipynb
+│   ├── 05_scoring_pipeline.ipynb
+│
+├── src/                              # Funciones de soporte Python
+│   ├── features.py
+│   ├── modelo.py
+│
+├── outputs/
+│   ├── modelos_ml/
+│   ├── tablas_resultado/
+│
+├── dashboard/                        # Power BI (opcional)
+│
+├── README.md                         # Explicación ejecutiva
+├── requirements.txt                  # Dependencias
+```
+
+## Objetivos
+
+1. Comprender los patrones de compra de los clientes.
+2. Segmentar a los compradores según su comportamiento.
+3. Predecir la probabilidad de recompra y la siguiente compra.
+4. Recomendar acciones promocionales basadas en las predicciones.
+
+## Flujo de trabajo
+
+1. **Ingesta y limpieza**: Lectura de archivos CSV con PySpark, validación de datos y creación de tablas integradas.
+2. **Exploración**: Análisis exploratorio con SQL/PySpark para detectar tendencias y clientes activos o inactivos.
+3. **Segmentación**: Cálculo de métricas RFM y clustering con K-means para definir perfiles de clientes.
+4. **Modelado**: Entrenamiento de un modelo de clasificación binaria para predecir la probabilidad de recompra.
+5. **Scoring y Deploy**: Registro y despliegue de modelos con MLflow, así como generación de resultados en tablas.
+6. **Visualización**: Creación de paneles de control (opcional) en Power BI o en las visualizaciones de Databricks.
+
+## Indicadores de éxito
+
+- AUC del modelo superior a 0.75.
+- Al menos tres segmentos de clientes diferenciados y accionables.
+- Pipeline reproducible y fácil de seguir.
+
+## Uso rápido
+
+Instalar dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+Explorar el notebook de ingesta:
+
+```bash
+jupyter notebook notebooks/01_ingesta_datos.ipynb
+```
+
+Este repositorio forma parte de un portafolio de proyectos de ciencia de datos enfocados en retail.

--- a/oxxo-retail-predictive-analytics/dashboard/README.md
+++ b/oxxo-retail-predictive-analytics/dashboard/README.md
@@ -1,0 +1,1 @@
+Coloque aquí los archivos del dashboard.

--- a/oxxo-retail-predictive-analytics/data/README.md
+++ b/oxxo-retail-predictive-analytics/data/README.md
@@ -1,0 +1,1 @@
+Coloque aquí los CSV de Instacart.

--- a/oxxo-retail-predictive-analytics/notebooks/01_ingesta_datos.ipynb
+++ b/oxxo-retail-predictive-analytics/notebooks/01_ingesta_datos.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ingesta de datos\n",
+    "Primer paso: leer archivos CSV de Instacart y validarlos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "spark = SparkSession.builder.appName('instacart').getOrCreate()\n",
+    "\n",
+    "# Ruta de ejemplo (ajustar a la ubicación real)\n",
+    "orders = spark.read.csv('../data/orders.csv', header=True, inferSchema=True)\n",
+    "orders.printSchema()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/oxxo-retail-predictive-analytics/notebooks/README.md
+++ b/oxxo-retail-predictive-analytics/notebooks/README.md
@@ -1,0 +1,1 @@
+Notebooks de análisis y modelado.

--- a/oxxo-retail-predictive-analytics/outputs/README.md
+++ b/oxxo-retail-predictive-analytics/outputs/README.md
@@ -1,0 +1,1 @@
+Modelos y tablas de resultados generados.

--- a/oxxo-retail-predictive-analytics/outputs/modelos_ml/README.md
+++ b/oxxo-retail-predictive-analytics/outputs/modelos_ml/README.md
@@ -1,0 +1,1 @@
+Modelos entrenados.

--- a/oxxo-retail-predictive-analytics/outputs/tablas_resultado/README.md
+++ b/oxxo-retail-predictive-analytics/outputs/tablas_resultado/README.md
@@ -1,0 +1,1 @@
+Tablas de resultados del scoring.

--- a/oxxo-retail-predictive-analytics/requirements.txt
+++ b/oxxo-retail-predictive-analytics/requirements.txt
@@ -1,0 +1,4 @@
+pyspark
+pandas
+scikit-learn
+mlflow

--- a/oxxo-retail-predictive-analytics/src/features.py
+++ b/oxxo-retail-predictive-analytics/src/features.py
@@ -1,0 +1,8 @@
+"""Funciones para ingeniería de features del proyecto OXXO."""
+
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+
+def agregar_features_basicos(df: DataFrame) -> DataFrame:
+    """Ejemplo de función para crear columnas adicionales."""
+    return df.withColumn('es_fin_de_semana', F.dayofweek('order_dow').isin([6,7]))

--- a/oxxo-retail-predictive-analytics/src/modelo.py
+++ b/oxxo-retail-predictive-analytics/src/modelo.py
@@ -1,0 +1,12 @@
+"""Entrenamiento de modelos de probabilidad de recompra."""
+
+from pyspark.ml.classification import LogisticRegression
+from pyspark.ml.feature import VectorAssembler
+from pyspark.sql import DataFrame
+
+def entrenar_modelo(df: DataFrame, features: list, label: str = 'recompra'):
+    assembler = VectorAssembler(inputCols=features, outputCol='features')
+    datos = assembler.transform(df)
+    lr = LogisticRegression(featuresCol='features', labelCol=label)
+    modelo = lr.fit(datos)
+    return modelo


### PR DESCRIPTION
## Summary
- add new project folder `oxxo-retail-predictive-analytics`
- include README detailing objectives and workflow
- add placeholder notebooks and python modules for features and modeling

## Testing
- `pip install -r requirements.txt`
- `python scripts/ag_exports_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_685c788488c48326892b61437ea0f807